### PR TITLE
Try pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - main
     tags:
       - '*.*.*'
-  pull_request:
+  pull_request_target:
 
 env:
   docker_repository: nlpsandbox/notebooks


### PR DESCRIPTION
Attempt to fix issue when a PR is opened from a fork repository and the CI/CD workflow fails because it could not access the Secrets. The solution is introduced [here](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/).