### PR TITLE
Add notebook to process Mayo COVID-19 dataset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,12 @@ services:
     command: ${IDE}
     volumes:
       - .:/home/${USERNAME}/nlpsandbox:rw
-    # networks:
-    #   - data-node
+    networks:
+      - nlpsandbox
     ports:
       - "${HOST_RSTUDIO_PORT}:8787"
       - "${HOST_JUPYTER_PORT}:8888"
 
-# networks:
-#   data-node:
-#     external: true
-#     name: data-node_default
+networks:
+  nlpsandbox:
+    name: nlpsandbox


### PR DESCRIPTION
## Goal

- Add notebook to process Mayo COVID-19 dataset. Use the same approach as for processing the PHI annotation dataset.